### PR TITLE
#73 Implement Cookies to log user

### DIFF
--- a/back-end/routes/room.js
+++ b/back-end/routes/room.js
@@ -27,14 +27,14 @@ router.get("/room", function (req,res) {
         res.send({ valid: false, msg: "An error occured." });
         return;
       }
-      console.log(result);
+      // console.log(result);
       if (result.length == 0) {
         res.send({ valid: false, msg: "Invalid Invite Code" });
         return;
       }
-      req.session.groupID = invCode;
+      const groupname = result[0].groupName;
       res.status(200);
-      res.send({ valid: true, msg: null });
+      res.send({ valid: true, msg: null, groupname: groupname });
     });
 });
   

--- a/back-end/routes/user.js
+++ b/back-end/routes/user.js
@@ -4,9 +4,10 @@ const User = require("../models/user");
 const Group = require("../models/group");
 
 router.post("/user", function (req, res) {
-    req.session.groupID = "03307"; // this is temporary until Issue #73
     const name = req.body.userName;
-    const newUser = new User({groupId:req.session.groupID, name: name, dishPreferences: []});
+    const id = req.body.groupID;
+    const newUser = new User({groupId:id, name: name, dishPreferences: []});
+
     newUser.save((err, result) => {
       if (err) {
         // console.log(err);
@@ -15,7 +16,7 @@ router.post("/user", function (req, res) {
         return;
       }
     //   console.log(result);
-      Group.findOneAndUpdate({groupId: req.session.groupID}, {$addToSet: {friends: newUser}}, {new: true}, (err, doc) => {
+      Group.findOneAndUpdate({groupId: id}, {$addToSet: {friends: newUser}}, {new: true}, (err, doc) => {
         if (err) {
             // console.log("Something wrong when updating the data");
             res.status(500);

--- a/back-end/test/app.test.js
+++ b/back-end/test/app.test.js
@@ -5,8 +5,9 @@ const server = require("../app");
 chai.should();
 chai.use(chaiHttp);
 
+let invite;
+
 describe('Invite Code', () => {
-  let invite;
 
   // POST Room Creation
   describe("POST /room", () => {
@@ -62,7 +63,7 @@ describe('Create new User', () => {
   // POST User Creation
   describe("POST  /user", () => {
     it("It should create and store a new user in the DB", (done) => {
-      const user = {userName : "testUser"};
+      const user = {userName : "testUser", groupID: invite.roomId};
       chai.request(server)
         .post("/user")
         .send(user)

--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -20,6 +20,7 @@
         "react-router-dom": "^5.3.0",
         "react-scripts": "4.0.3",
         "react-spinner-material": "^1.3.1",
+        "universal-cookie": "^4.0.4",
         "web-vitals": "^1.0.1"
       },
       "devDependencies": {
@@ -2849,6 +2850,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "node_modules/@types/eslint": {
       "version": "7.28.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.1.tgz",
@@ -4608,6 +4614,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5253,6 +5260,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
       "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "devOptional": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -10030,6 +10038,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "devOptional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -15406,6 +15415,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "devOptional": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -18197,6 +18207,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "dependencies": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
       }
     },
     "node_modules/universalify": {
@@ -22303,6 +22322,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "@types/eslint": {
       "version": "7.28.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.1.tgz",
@@ -23717,7 +23741,8 @@
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "devOptional": true
     },
     "bindings": {
       "version": "1.5.0",
@@ -24235,6 +24260,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
       "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "devOptional": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -27950,6 +27976,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "devOptional": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -32176,6 +32203,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "devOptional": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -34386,6 +34414,15 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
         "crypto-random-string": "^1.0.0"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
       }
     },
     "universalify": {

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -15,6 +15,7 @@
     "react-router-dom": "^5.3.0",
     "react-scripts": "4.0.3",
     "react-spinner-material": "^1.3.1",
+    "universal-cookie": "^4.0.4",
     "web-vitals": "^1.0.1"
   },
   "scripts": {

--- a/front-end/src/pages/ChooseCuisine.jsx
+++ b/front-end/src/pages/ChooseCuisine.jsx
@@ -7,9 +7,41 @@ import Button from "../components/Button";
 import { Carousel } from 'react-responsive-carousel';
 import "react-responsive-carousel/lib/styles/carousel.min.css"; // requires a loader
 
+import { Redirect } from 'react-router';
+
+import Cookies from 'universal-cookie';
+const cookies = new Cookies();
+
 const data = require('../data/cuisines.json');
 
 function ChooseCuisine() {
+  if (!cookies.get("groupID")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: {error: "nogroup"}
+    }}
+    />)
+  }
+
+  if (!cookies.get("user")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: {error: "nouser"}
+    }}
+    />)
+  }
+
+  if (cookies.get("cuisine")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "cuisine" }
+    }}
+    />)
+  }
+
   return (
     <div className="Cuisine">
       <h1 id = "heading">Choose a Cuisine</h1>

--- a/front-end/src/pages/CreateRoom.jsx
+++ b/front-end/src/pages/CreateRoom.jsx
@@ -8,6 +8,10 @@ import PlacesAutocomplete, {geocodeByAddress, getLatLng} from 'react-places-auto
 
 import { useHistory } from "react-router-dom";
 import { validateForm } from "../utils/validation"
+import { Redirect } from 'react-router';
+
+import Cookies from 'universal-cookie';
+const cookies = new Cookies();
 
 const MAX_CAPACITY = 20;
 const MIN_CAPACITY = 2;
@@ -34,6 +38,8 @@ function CreateRoom() {
     );
 
     const roomId = response.roomId;
+    cookies.set("groupID", roomId, { expires: 0 });
+    cookies.set("groupName", name, { expires: 0 })
     history.push(`/invite`, { roomId: roomId });
   };
 
@@ -43,6 +49,15 @@ function CreateRoom() {
     const latLng = await getLatLng(results[0]);
     setLat(latLng.lat);
     setLong(latLng.lng);
+  }
+
+  if (cookies.get("groupID")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "group", group: cookies.get("groupName"), next: "/create"}
+    }}
+    />)
   }
 
   return (

--- a/front-end/src/pages/CuisineVote.jsx
+++ b/front-end/src/pages/CuisineVote.jsx
@@ -4,10 +4,41 @@ import React from 'react';
 import QuestionMark from '../img/question-mark.svg';
 import SelectChoice from '../img/select-choice.svg';
 import { useHistory } from "react-router-dom";
+import { Redirect } from 'react-router';
 
+import Cookies from 'universal-cookie';
+const cookies = new Cookies();
 
 function CuisineVote() {
   const history = useHistory();
+
+  if (!cookies.get("groupID")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nogroup" }
+    }}
+    />)
+  }
+
+  if (!cookies.get("user")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nouser" }
+    }}
+    />)
+  }
+
+  if (cookies.get("cuisine")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "cuisine" }
+    }}
+    />)
+  }
+
   return (
     <div className="Cuisine">
       <h1 id = "cuisine-heading">Vote on Cuisine</h1>

--- a/front-end/src/pages/Error.css
+++ b/front-end/src/pages/Error.css
@@ -1,3 +1,32 @@
-.Error #heading {
-    color: red;
+.Error {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 }
+
+.Error .heading {
+    color: #8b5858;
+}
+
+.Error .info {
+    letter-spacing: 2px;
+    font-weight: 300;
+}
+
+.Error .button-group {
+    margin-top: 70px;
+}
+
+.Error .bold {
+    font-weight: bold;
+}
+
+.Error .space-sides {
+    margin-left: 10px;
+    margin-right: 10px;
+}
+
+.Error .space-top {
+    margin-top: 30px;
+}
+

--- a/front-end/src/pages/Error.jsx
+++ b/front-end/src/pages/Error.jsx
@@ -23,11 +23,11 @@ function Error(props) {
   };
 
   useEffect(() => {
-    const nextLink = props.location.state.next ? props.location.state.next : "/";
+    const nextLink = props.location.state?.next ? props.location.state?.next : "/";
     setNext(nextLink);
-    setError(props.location.state.error);
-    setGroup(props.location.state.group);
-    setUser(props.location.state.user);
+    setError(props.location.state?.error);
+    setGroup(props.location.state?.group);
+    setUser(props.location.state?.user);
   });
 
   let component = null;

--- a/front-end/src/pages/Error.jsx
+++ b/front-end/src/pages/Error.jsx
@@ -1,11 +1,113 @@
 import './Error.css';
 
-import React from 'react';
+import React, { useEffect } from 'react';
+import Button from "../components/Button";
+import { Link } from "react-router-dom";
 
-function Error() {
+import Cookies from 'universal-cookie';
+const cookies = new Cookies();
+
+function Error(props) {
+  const [error, setError] = React.useState("undefined");
+  const [group, setGroup] = React.useState("undefined");
+  const [user, setUser] = React.useState("undefined");
+  const [next, setNext] = React.useState("/");
+
+  const resetCookies = () => {
+    cookies.remove("groupID");
+    cookies.remove("groupName");
+    cookies.remove("user");
+    window.location.href = `${next}`;
+    // cookies.remove("cuisine");
+    // cookies.remove("preferred");
+  };
+
+  useEffect(() => {
+    const nextLink = props.location.state.next ? props.location.state.next : "/";
+    setNext(nextLink);
+    setError(props.location.state.error);
+    setGroup(props.location.state.group);
+    setUser(props.location.state.user);
+  });
+
+  let component = null;
+
+  switch(error) {
+    case "group":
+      component = <div>
+        <h1 className = "heading">Already in a group</h1>
+          <p className="info">Uh oh...</p>
+          <p className = "info space-sides">It seems like you already joined a group called <span className="bold">{group}</span></p>
+          <div className="button-group">
+            <Button text = "Leave Group" width="250px" height="50px" bg="#6e6d63" onClick={resetCookies}/>
+          </div>
+      </div>;
+      break;
+    case "nogroup":
+      component = <div>
+        <h1 className = "heading">No Group Found</h1>
+        <p className = "info">Please create or join a group before voting</p>
+        <div className = "button-group">
+         <Link to="/create">
+           <Button text = "Create" width="250px" height="40px" bg="#b7b4a7"/>
+         </Link>
+         <Link to="/join">
+           <Button text = "Join" width="250px" height="40px" bg="#787567"/>
+         </Link>
+        </div>
+      </div>;
+      break;
+    case "user":
+      component = <div>
+        <h1 className="heading">Already set name</h1>
+        <p className="info space-sides">Hey <span className="bold">{user}</span>, It seems like you are registered already :)!</p>
+        <p className="info space-sides space-top">If this is a mistake, reset your current session with us.</p>
+        <div className="button-group">
+            <Button text = "Reset" width="250px" height="50px" bg="#6e6d63" onClick={resetCookies}/>
+        </div>      
+        </div>;
+      break;
+    case "nouser":
+      component = <div>
+        <h1 className="heading">No User Found</h1>
+        <p className="info space-sides"> Please set your user information before continuing </p>
+        <div className="button-group">
+          <Link to="/new-user">
+            <Button text = "Set User Info" width="250px" height="50px" bg="#6e6d63"/>
+          </Link>
+        </div>
+      </div>;
+      break;
+    case "cuisine": 
+      component = <div>
+        <h1 className="heading">Already Voted</h1>
+        <p className="info space-sides"></p>
+      </div>
+      break;
+    case "nocuisine": 
+      component =  <div>
+        <h1 className="heading">No Cuisine found</h1>
+        <p className="info space-sides">It seems like you have not voted for a cuisine</p>
+        <div className="button-group">
+          <Link to="/cuisine">
+            <Button text = "Vote" width="250px" height="50px" bg="#6e6d63"/>
+          </Link>
+        </div>     
+      </div>
+      break;
+    case "preferred": 
+      component = <div>
+        <h1 className="heading">Already selected preferences</h1>
+        <p className="info space-sides"></p>
+      </div>
+    break;
+    default:
+      component = <div><h1 className="heading">An error occured</h1></div>;
+  }
+
   return (
     <div className="Error">
-      <h1 id="heading">SOMETHING WENT WRONG</h1>
+      {component}
     </div>
   );
 }

--- a/front-end/src/pages/Home.jsx
+++ b/front-end/src/pages/Home.jsx
@@ -1,12 +1,9 @@
 import "./Home.css";
 
-import React, { Fragment, useEffect } from "react";
+import React, { Fragment } from "react";
 import HomePageLogo from "../components/HomePageLogo";
 import Button from "../components/Button";
 import { Link } from "react-router-dom";
-
-import Cookies from 'universal-cookie';
-const cookies = new Cookies();
 
 function Home() {
 

--- a/front-end/src/pages/Home.jsx
+++ b/front-end/src/pages/Home.jsx
@@ -1,11 +1,15 @@
 import "./Home.css";
 
-import React, { Fragment } from "react";
+import React, { Fragment, useEffect } from "react";
 import HomePageLogo from "../components/HomePageLogo";
 import Button from "../components/Button";
 import { Link } from "react-router-dom";
 
+import Cookies from 'universal-cookie';
+const cookies = new Cookies();
+
 function Home() {
+
   return (
   <Fragment>
     <div className = "Home">

--- a/front-end/src/pages/JoinRoom.jsx
+++ b/front-end/src/pages/JoinRoom.jsx
@@ -8,6 +8,10 @@ import Spacer from '../components/Spacer';
 import { validateForm } from "../utils/validation"
 import { useHistory } from "react-router-dom";
 import { get } from '../utils/request';
+import { Redirect } from 'react-router';
+
+import Cookies from 'universal-cookie';
+const cookies = new Cookies();
 
 function JoinRoom() {
   const [inviteCode, setInviteCode] = React.useState('');
@@ -21,15 +25,25 @@ function JoinRoom() {
         inviteCode
       }
     );
-
+    
     if (response.valid) {
+      cookies.set("groupID", inviteCode, { expires: 0 });
+      cookies.set("groupName", response.groupname, { expires: 0 });
       history.push(`/new-user`);
     }
     else {
-      console.log("invalid code! do something here");
       setErrorMessage(response.msg);
     }
   };
+
+  if (cookies.get("groupID")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "group", group: cookies.get("groupName"), next: "/join"}
+    }}
+    />)
+  }
 
   return (
     <div className="JoinRoom">

--- a/front-end/src/pages/PreferredDish.jsx
+++ b/front-end/src/pages/PreferredDish.jsx
@@ -2,11 +2,50 @@ import './PreferredDish.css';
 
 import React from 'react';
 import { Link } from "react-router-dom";
+import { Redirect } from 'react-router';
 import Button from '../components/Button';
+import Cookies from 'universal-cookie';
 
 const dishes = [{name: "dish name 1", value: "dish-1"}, {name: "dish name 2", value: "dish-2"}, {name: "dish name 3", value: "dish-3"}];
+const cookies = new Cookies();
 
 function PreferredDish() {
+  if (!cookies.get("groupID")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nogroup" }
+    }}
+    />)
+  }
+
+  if (!cookies.get("user")){
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nouser" }
+    }}
+    />)
+  }
+
+  if (!cookies.get("cuisine")){
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nocuisine", next: "/cuisine" }
+    }}
+    />)
+  }
+
+  if (cookies.get("preferred")){
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "preferred" }
+    }}
+    />)
+  }
+
   return (
     <div className="PreferredDish">
       <Link to="/wait">

--- a/front-end/src/pages/RandomCuisine.jsx
+++ b/front-end/src/pages/RandomCuisine.jsx
@@ -2,8 +2,40 @@ import './RandomCuisine.css';
 
 import React from 'react';
 import Button from '../components/Button'
+import { Redirect } from 'react-router';
+
+import Cookies from 'universal-cookie';
+const cookies = new Cookies();
 
 function RandomCuisine() {
+
+  if (!cookies.get("groupID")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nogroup" }
+    }}
+    />)
+  }
+
+  if (!cookies.get("user")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nouser" }
+    }}
+    />)
+  }
+
+  if (cookies.get("cuisine")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "cuisine" }
+    }}
+    />)
+  }
+
   return (
     <div className="RandomCuisine">
       <div id="random-cuisine-title-top"> 

--- a/front-end/src/pages/RestaurantDetails.jsx
+++ b/front-end/src/pages/RestaurantDetails.jsx
@@ -5,6 +5,10 @@ import { useParams } from "react-router-dom";
 import Button from "../components/Button";
 import { get } from "../utils/request";
 import Loading from '../components/Loading';
+import { Redirect } from 'react-router';
+
+import Cookies from 'universal-cookie';
+const cookies = new Cookies();
 
 // const data = {
 //   restaurant_name: "Silver Spurs",
@@ -30,6 +34,33 @@ import Loading from '../components/Loading';
 function RestaurantDetails() {
   let { restaurantId } = useParams();
   const [restaurant, setRestaurant] = React.useState(null);
+
+  if (!cookies.get("groupID")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nogroup" }
+    }}
+    />)
+  }
+
+  if (!cookies.get("user")){
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nouser" }
+    }}
+    />)
+  }
+
+  if (!cookies.get("cuisine")){
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nocuisine", next: "/cuisine"  }
+    }}
+    />)
+  }
 
   React.useEffect(() => {
     fetchRestaurant(restaurantId);

--- a/front-end/src/pages/ResultsPage.jsx
+++ b/front-end/src/pages/ResultsPage.jsx
@@ -3,6 +3,10 @@ import ResultsCell from "../components/ResultsCell";
 import { get } from "../utils/request";
 
 import React from "react";
+import { Redirect } from 'react-router';
+
+import Cookies from 'universal-cookie';
+const cookies = new Cookies();
 
 // const restaurauntList = [
 //   {
@@ -63,6 +67,34 @@ import React from "react";
 
 function ResultsPage() {
   const [restaurants, setRestaurants] = React.useState([]);
+
+  if (!cookies.get("groupID")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nogroup" }
+    }}
+    />)
+  }
+
+  if (!cookies.get("user")){
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nouser" }
+    }}
+    />)
+  }
+
+  if (!cookies.get("cuisine")){
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nocuisine", next: "/cuisine"  }
+    }}
+    />)
+  }
+
 
   React.useEffect(() => {
     fetchRestaurants();

--- a/front-end/src/pages/TeamPage.jsx
+++ b/front-end/src/pages/TeamPage.jsx
@@ -31,7 +31,7 @@ function TeamPage() {
           <p>
             Food with Friends is a web application that aims to make
             decision-making for where to eat easy. Users can invite their
-            entourage to a "room" where they can choose a cuisine they prefer
+            entourage to a &quot;room&quot; where they can choose a cuisine they prefer
             (e.g. Italian, Chinese, etc.), vote on it, and go on to choose a
             restaurant together.
           </p>

--- a/front-end/src/pages/User.jsx
+++ b/front-end/src/pages/User.jsx
@@ -4,9 +4,14 @@ import Input from '../components/Input';
 import Button from '../components/Button';
 import { post } from '../utils/request';
 import { useHistory } from "react-router-dom";
+import { Redirect } from 'react-router';
+
+import Cookies from 'universal-cookie';
+const cookies = new Cookies();
 
 function User() {
   const [userName, setName] = React.useState("");
+  const [groupID] = React.useState(cookies.get("groupID"));
 
   const history = useHistory();
 
@@ -14,17 +19,37 @@ function User() {
     const response = await post(
       '/user',
       {
-        userName
+        userName,
+        groupID
       }
     );
 
     if (response.success) {
       history.push(`/wait`);
+      cookies.set("user", userName, { expires: 0 });
     }
     else {
       history.push(`/error`);
     }
   };
+
+  if (!cookies.get("groupID")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nogroup" }
+    }}
+    />)
+  }
+
+  if (cookies.get("user")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "user", user: cookies.get("user") }
+    }}
+    />)
+  }
 
   return (
     <div className="User">

--- a/front-end/src/pages/WinningCuisine.jsx
+++ b/front-end/src/pages/WinningCuisine.jsx
@@ -4,7 +4,40 @@ import React from 'react';
 import Button from '../components/Button';
 import winningLogo from '../img/winningimg.jpeg';
 
+import { Redirect } from 'react-router';
+
+import Cookies from 'universal-cookie';
+const cookies = new Cookies();
+
 function WinningCuisine(props) {
+
+  if (!cookies.get("groupID")) {
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nogroup" }
+    }}
+    />)
+  }
+
+  if (!cookies.get("user")){
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nouser" }
+    }}
+    />)
+  }
+
+  if (!cookies.get("cuisine")){
+    return (
+    <Redirect to={{
+      pathname: "/error",
+      state: { error: "nocuisine", next: "/cuisine" }
+    }}
+    />)
+  }
+  
   return (
     <div className="WinningCuisine">
       <div className="WinningImage"><img id="winImg" src={winningLogo} alt="Winning cuisine image"/></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,46 @@
       "dependencies": {
         "axios": "^0.24.0",
         "documenu": "^1.1.0",
+        "react-cookie": "^4.1.1",
         "react-places-autocomplete": "^7.3.0"
       },
       "devDependencies": {
         "concurrently": "^6.3.0"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+    },
+    "node_modules/@types/react": {
+      "version": "17.0.36",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.36.tgz",
+      "integrity": "sha512-CUFUp01OdfbpN/76v4koqgcpcRGT3sYOq3U3N6q0ZVGcyeP40NUdVU+EWe3hs34RNaTefiYyBzOpxBBidCc5zw==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -128,6 +163,19 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+    },
     "node_modules/date-fns": {
       "version": "2.25.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.25.0.tgz",
@@ -209,6 +257,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -274,6 +330,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
       }
     },
     "node_modules/react-is": {
@@ -376,6 +445,15 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
+    "node_modules/universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "dependencies": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -431,6 +509,40 @@
     }
   },
   "dependencies": {
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
+    "@types/prop-types": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+    },
+    "@types/react": {
+      "version": "17.0.36",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.36.tgz",
+      "integrity": "sha512-CUFUp01OdfbpN/76v4koqgcpcRGT3sYOq3U3N6q0ZVGcyeP40NUdVU+EWe3hs34RNaTefiYyBzOpxBBidCc5zw==",
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -517,6 +629,16 @@
         "yargs": "^16.2.0"
       }
     },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
+    "csstype": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+    },
     "date-fns": {
       "version": "2.25.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.25.0.tgz",
@@ -569,6 +691,14 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -623,6 +753,16 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
+      }
+    },
+    "react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
       }
     },
     "react-is": {
@@ -700,6 +840,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      }
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "axios": "^0.24.0",
     "documenu": "^1.1.0",
+    "react-cookie": "^4.1.1",
     "react-places-autocomplete": "^7.3.0"
   }
 }


### PR DESCRIPTION
In this PR, we've added cookies on the frontend to keep track of the current user's session and to prevent them from accessing pages before they're supposed to by rendering error pages instead. 

One thing to note, if someone tries to directly access the `/error` endpoint, it crashes. Not sure how to fix it so I've opened up a new bug task #143.

Also, still need to add styling for the duplicate cuisine/preferred dishes errors but was blocked since the functionality isn't there yet. Though it should be quick to implement. 

Examples

**If the user tries to access other pages without joining/creating a group**

<img width="376" alt="Screen Shot 2021-11-24 at 7 16 41 PM" src="https://user-images.githubusercontent.com/21044058/143328940-48820bee-e62d-47a1-97bf-30befdb4a04e.png">

**If the user tries to recreate/rejoin a new group**

<img width="400" alt="Screen Shot 2021-11-24 at 7 17 46 PM" src="https://user-images.githubusercontent.com/21044058/143329541-3659d804-77bd-43df-9099-cb879b2a3f88.png">


**If the user tries to get ahead without setting their name**

<img width="387" alt="Screen Shot 2021-11-24 at 7 18 06 PM" src="https://user-images.githubusercontent.com/21044058/143329586-f3b6d44b-9db3-442f-ac6a-6bdd4c83fb1e.png">

**If the user tries to reset their name**

<img width="396" alt="Screen Shot 2021-11-24 at 7 18 21 PM" src="https://user-images.githubusercontent.com/21044058/143329642-2617a826-a9ca-4d49-96a3-1dd0e699960d.png">

**If the user tries to get ahead without voting on a cuisine**

<img width="371" alt="Screen Shot 2021-11-24 at 7 18 31 PM" src="https://user-images.githubusercontent.com/21044058/143329669-581248f5-ebae-4572-9c55-74da9c0a0825.png">
